### PR TITLE
Update SV-230223 to check for fips kernelopt

### DIFF
--- a/controls/SV-230223.rb
+++ b/controls/SV-230223.rb
@@ -99,7 +99,7 @@ following command:
     grub_config = command('grub2-editenv - list').stdout
   
     describe parse_config(grub_config) do
-      its('kernelopts') { should match /audit=1/ }
+      its('kernelopts') { should match /fips=1/ }
     end
   
     describe file('/proc/sys/crypto/fips_enabled') do


### PR DESCRIPTION
Control SV-230468.rb handles checking for the audit kernel option, this control by its own documentation should be checking for the fips setting in the kernelops parameter.